### PR TITLE
Move database operations out of command

### DIFF
--- a/Classes/Domain/Repository/StackRepository.php
+++ b/Classes/Domain/Repository/StackRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package jweiland/indexnow.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace JWeiland\IndexNow\Domain\Repository;
+
+use Doctrine\DBAL\FetchMode;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+final class StackRepository
+{
+    private const TABLE_NAME = 'tx_indexnow_stack';
+
+    /**
+     * @var QueryBuilder
+     */
+    private $queryBuilder;
+
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    public function findAll(): iterable
+    {
+        $statement = $this->queryBuilder
+            ->select('uid', 'url')
+            ->from(self::TABLE_NAME)
+            ->execute();
+
+        while ($urlRecord = $statement->fetch(FetchMode::ASSOCIATIVE)) {
+            yield $urlRecord;
+        }
+    }
+
+    public function deleteByUid(int $uid): void
+    {
+        $this->queryBuilder
+            ->delete(self::TABLE_NAME)
+            ->where(
+                $this->queryBuilder->expr()->eq('uid', $this->queryBuilder->createNamedParameter($uid))
+            )
+            ->execute();
+    }
+}

--- a/Classes/Notifier/SearchEngineNotifier.php
+++ b/Classes/Notifier/SearchEngineNotifier.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
-namespace JWeiland\IndexNow\Service;
+namespace JWeiland\IndexNow\Notifier;
 
 use GuzzleHttp\Exception\ClientException;
 use Psr\Log\LoggerAwareInterface;
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /*
  * Service to communicate with the search engine
  */
-class SearchEngineService implements LoggerAwareInterface
+class SearchEngineNotifier implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
@@ -35,7 +35,7 @@ class SearchEngineService implements LoggerAwareInterface
         $this->requestFactory = $requestFactory;
     }
 
-    public function notifySearchEngine(string $url): bool
+    public function notify(string $url): bool
     {
         $isValidRequest = false;
         if (GeneralUtility::isValidUrl($url)) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -17,3 +17,15 @@ services:
       - name: 'console.command'
         command: 'indexnow:notify'
         schedulable: true
+
+  querybuilder.tx_indexnow_stack:
+    class: 'TYPO3\CMS\Core\Database\Query\QueryBuilder'
+    factory:
+      - '@TYPO3\CMS\Core\Database\ConnectionPool'
+      - 'getQueryBuilderForTable'
+    arguments:
+      - 'tx_indexnow_stack'
+
+  JWeiland\IndexNow\Domain\Repository\StackRepository:
+    arguments:
+      $queryBuilder: '@querybuilder.tx_indexnow_stack'


### PR DESCRIPTION
A new StackRepository is introduced which is responsible
for the database operations. The URL records are yielded to
preserve memory.

The output of the command was improved, now the total number
of processed URLs along with skipped and erroneous URLs is given.

The SearchEngineService was renamed to SearchEngineNotifier
to make its purpose clearer.